### PR TITLE
Add ReadOnlySpan<byte> overloads

### DIFF
--- a/src/MurmurHash.Net/MurmurHash3.cs
+++ b/src/MurmurHash.Net/MurmurHash3.cs
@@ -5,7 +5,13 @@ namespace MurmurHash.Net
 {
     public class MurmurHash3
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint Hash32(Span<byte> bytes, uint seed)
+        {
+            return Hash32((ReadOnlySpan<byte>)bytes, seed);
+        }
+
+        public static uint Hash32(ReadOnlySpan<byte> bytes, uint seed)
         {
             var length = bytes.Length;
             var h1 = seed;
@@ -32,7 +38,7 @@ namespace MurmurHash.Net
 
                 h1 ^= RotateLeft(num * 3432918353U, 15) * 461845907U;
             }
-            
+
             h1 = FMix(h1 ^ (uint) length);
 
             return h1;
@@ -52,5 +58,4 @@ namespace MurmurHash.Net
             return h ^ h >> 16;
         }
     }
-
 }

--- a/src/MurmurHash.Net/MurmurHash3.cs
+++ b/src/MurmurHash.Net/MurmurHash3.cs
@@ -5,12 +5,6 @@ namespace MurmurHash.Net
 {
     public class MurmurHash3
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint Hash32(Span<byte> bytes, uint seed)
-        {
-            return Hash32((ReadOnlySpan<byte>)bytes, seed);
-        }
-
         public static uint Hash32(ReadOnlySpan<byte> bytes, uint seed)
         {
             var length = bytes.Length;

--- a/tests/MurmurHash.Net.Tests/MurmurHashTests.cs
+++ b/tests/MurmurHash.Net.Tests/MurmurHashTests.cs
@@ -1,5 +1,4 @@
 ﻿using FluentAssertions;
-using System;
 using Xunit;
 
 namespace MurmurHash.Net.Tests
@@ -28,11 +27,7 @@ namespace MurmurHash.Net.Tests
         [InlineData(new byte[] {0x0}, 0U, 0x514E28B7U)]
         public void SmokeTest(byte[] bytes, uint seed, uint expectedHash)
         {
-            var asSpan = new Span<byte>(bytes);
-            var asReadOnlySpan = new ReadOnlySpan<byte>(bytes);
-
-            MurmurHash3.Hash32(asSpan, seed).Should().Be(expectedHash);
-            MurmurHash3.Hash32(asReadOnlySpan, seed).Should().Be(expectedHash);
+            MurmurHash3.Hash32(bytes, seed).Should().Be(expectedHash);
         }
     }
 }

--- a/tests/MurmurHash.Net.Tests/MurmurHashTests.cs
+++ b/tests/MurmurHash.Net.Tests/MurmurHashTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using System;
 using Xunit;
 
 namespace MurmurHash.Net.Tests
@@ -27,7 +28,11 @@ namespace MurmurHash.Net.Tests
         [InlineData(new byte[] {0x0}, 0U, 0x514E28B7U)]
         public void SmokeTest(byte[] bytes, uint seed, uint expectedHash)
         {
-            MurmurHash3.Hash32(bytes, seed).Should().Be(expectedHash);
+            var asSpan = new Span<byte>(bytes);
+            var asReadOnlySpan = new ReadOnlySpan<byte>(bytes);
+
+            MurmurHash3.Hash32(asSpan, seed).Should().Be(expectedHash);
+            MurmurHash3.Hash32(asReadOnlySpan, seed).Should().Be(expectedHash);
         }
     }
 }


### PR DESCRIPTION
Adds a ReadOnlySpan<byte> overload. The Span<byte> overload forwards to
the ReadOnlySpan<byte> implementation.

Adding a new overload maintains binary and reflection compability,
whereas just changing the parameter type is only source compatible.